### PR TITLE
FIX Model constructor - replace lodash each which breaks on return fa…

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21,10 +21,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // import test from './test';
 
 // Expose global 'whatwg-fetch' options
-var fetchOptions = exports.fetchOptions = _request.defaults;
 /* ==========================================================================
-ReactResource
-========================================================================== */
+   ReactResource
+   ========================================================================== */
+
+var fetchOptions = exports.fetchOptions = _request.defaults;
 
 function ReactResource() {
   for (var _len = arguments.length, kwargs = Array(_len), _key = 0; _key < _len; _key++) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,9 +21,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // import test from './test';
 
 // Expose global 'whatwg-fetch' options
-var fetchOptions = exports.fetchOptions = _request.defaults; /* ==========================================================================
-                                                                ReactResource
-                                                                ========================================================================== */
+var fetchOptions = exports.fetchOptions = _request.defaults;
+/* ==========================================================================
+ReactResource
+========================================================================== */
 
 function ReactResource() {
   for (var _len = arguments.length, kwargs = Array(_len), _key = 0; _key < _len; _key++) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10,10 +10,6 @@ var _assign = require('lodash/assign');
 
 var _assign2 = _interopRequireDefault(_assign);
 
-var _isEmpty = require('lodash/isEmpty');
-
-var _isEmpty2 = _interopRequireDefault(_isEmpty);
-
 var _request = require('./utils/request');
 
 var _ActionsBuilder = require('./ActionsBuilder');
@@ -25,11 +21,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // import test from './test';
 
 // Expose global 'whatwg-fetch' options
-/* ==========================================================================
-   ReactResource
-   ========================================================================== */
-
-var fetchOptions = exports.fetchOptions = _request.defaults;
+var fetchOptions = exports.fetchOptions = _request.defaults; /* ==========================================================================
+                                                                ReactResource
+                                                                ========================================================================== */
 
 function ReactResource() {
   for (var _len = arguments.length, kwargs = Array(_len), _key = 0; _key < _len; _key++) {
@@ -42,9 +36,7 @@ function ReactResource() {
     var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
     // Model instance data
-    if (!(0, _isEmpty2.default)(data)) {
-      (0, _assign2.default)(this, data);
-    }
+    (0, _assign2.default)(this, data);
 
     // Model instance actions
     actionsBuilder.instanceMethods(data, Model);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,9 +6,9 @@ Object.defineProperty(exports, "__esModule", {
 exports.fetchOptions = undefined;
 exports.default = ReactResource;
 
-var _each = require('lodash/each');
+var _assign = require('lodash/assign');
 
-var _each2 = _interopRequireDefault(_each);
+var _assign2 = _interopRequireDefault(_assign);
 
 var _isEmpty = require('lodash/isEmpty');
 
@@ -39,15 +39,11 @@ function ReactResource() {
   var actionsBuilder = new (Function.prototype.bind.apply(_ActionsBuilder2.default, [null].concat([Model], kwargs)))();
 
   function Model() {
-    var _this = this;
-
     var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
     // Model instance data
     if (!(0, _isEmpty2.default)(data)) {
-      (0, _each2.default)(data, function (val, key) {
-        return _this[key] = val;
-      });
+      (0, _assign2.default)(this, data);
     }
 
     // Model instance actions

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
    ReactResource
    ========================================================================== */
 
-import each from 'lodash/each';
+import assign from 'lodash/assign';
 import isEmpty from 'lodash/isEmpty';
 import { defaults } from './utils/request';
 import ActionsBuilder from './ActionsBuilder';
@@ -16,9 +16,7 @@ export default function ReactResource(...kwargs) {
 
   function Model(data = {}) {
     // Model instance data
-    if (!isEmpty(data)) {
-      each(data, (val, key) => this[key] = val);
-    }
+    assign(this, data);
 
     // Model instance actions
     actionsBuilder.instanceMethods(data, Model);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
    ========================================================================== */
 
 import assign from 'lodash/assign';
-import isEmpty from 'lodash/isEmpty';
 import { defaults } from './utils/request';
 import ActionsBuilder from './ActionsBuilder';
 // import test from './test';


### PR DESCRIPTION
Lodash each methods breaks when interatee returns false ("Iteratee functions may exit iteration early by explicitly returning false." - documentation).
Thus, assigning properties with value of false causes Model instance partially populated with data.

It's equivalent to assign on this, which will be a native call to Object.assign, doing exactly the same (copying own enumerable properties).

I kept the isEmpty check, but to me it's an useless check, since assign wont copy any property if there are none.