### PR TITLE
Handle non-JSON responses without failing

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -41,7 +41,23 @@ export default function request(url, options = {}) {
  */
 
 export function parseJSON(response) {
-  return response.json();
+  if (!isJSON(response.headers)) {
+    return response.text();
+  } else {
+    return response.json();
+  }
+}
+
+/**
+ * Verifies that the content returned is JSON
+ *
+ * @param  {object} headers from the network response
+ *
+ * @return {boolean} Whether the content-type includes JSON or not
+ */
+
+function isJSON(headers) {
+  return headers.get('content-type').match(/json/i);
 }
 
 /**


### PR DESCRIPTION
@cidevant: For Django and Rails, it is common for responses from delete actions to be an empty string or null, with a content type of text.

Since Interceptors run after the response goes through parseJSON, I have added a check to the headers to verify that the response is JSON. if it is not, I send back a promise containing the text of the response instead.