### PR TITLE
Add global + model based transformers.

### DIFF
--- a/src/ActionsBuilder.js
+++ b/src/ActionsBuilder.js
@@ -7,7 +7,7 @@ import each from 'lodash/each';
 import merge from 'lodash/merge';
 import isFunction from 'lodash/isFunction';
 import Action from './Action';
-import Interceptors from './Interceptors';
+import Stages from './Stages';
 
 export default class ActionsBuilder {
   static defaults = {
@@ -37,8 +37,9 @@ export default class ActionsBuilder {
       {}
     );
 
-    // `Model` interceptors
-    this.interceptors = new Interceptors(Model);
+    // `Model` interceptors and transformers
+    this.interceptors = new Stages(Model, 'interceptors');
+    this.transformers = new Stages(Model, 'transformers');
   }
   
   /**
@@ -72,7 +73,7 @@ export default class ActionsBuilder {
       Model[name] = (...kwargs) => {
         // Extract `data` from arguments and pass it as param to `Action` constructor
         const data = isFunction(kwargs[0]) ? {} : kwargs.shift();
-        const action = new Action(Model, name, cfg, data, mappings, this.interceptors);
+        const action = new Action(Model, name, cfg, data, mappings, this.interceptors, this.transformers);
 
         return action.promise(...kwargs);
       };
@@ -95,7 +96,7 @@ export default class ActionsBuilder {
 
     each(this.actions, (cfg, name) => {
       Model.prototype[`$${name}`] = (...kwargs) => {
-        const action = new Action(Model, name, cfg, data, mappings, this.interceptors);
+        const action = new Action(Model, name, cfg, data, mappings, this.interceptors, this.transformers);
         
         return action.promise(...kwargs);
       };

--- a/src/Stages.js
+++ b/src/Stages.js
@@ -29,20 +29,21 @@ import ReactResource from './index';
 import each from 'lodash/each';
 import isFunction from 'lodash/isFunction';
 
-export default class Interceptors {
-  constructor(Model) {
+export default class Stages {
+  constructor(Model, which) {
     this.Model = Model;
+    this.which = which;
   }
 
   request(config) {
     // Resource
-    each(ReactResource.interceptors, (i) => {
+    each(ReactResource[this.which], (i) => {
       if (isFunction(i.request)) config = config.then(i.request);
       if (isFunction(i.requestError)) config = config.catch(i.requestError);
     });
 
     // Model
-    each(this.Model.interceptors, (i) => {
+    each(this.Model[this.which], (i) => {
       if (isFunction(i.request)) config = config.then(i.request);
       if (isFunction(i.requestError)) config = config.catch(i.requestError);
     });
@@ -52,13 +53,13 @@ export default class Interceptors {
 
   response(promise) {
     // Resource
-    each(ReactResource.interceptors, (i) => {
+    each(ReactResource[this.which], (i) => {
       if (isFunction(i.response)) promise = promise.then(i.response);
       if (isFunction(i.responseError)) promise = promise.catch(i.responseError);
     });
 
     // Model
-    each(this.Model.interceptors, (i) => {
+    each(this.Model[this.which], (i) => {
       if (isFunction(i.response)) promise = promise.then(i.response);
       if (isFunction(i.responseError)) promise = promise.catch(i.responseError);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ export default function ReactResource(...kwargs) {
 
 // Global interceptors
 ReactResource.interceptors = [];
+ReactResource.transformers = [];
 
 if (typeof window !== 'undefined') {
   window.ReactResource = ReactResource;


### PR DESCRIPTION
Currently the only way to set a transform is on each and every request.
This allows for configuration of transforms at the global and model levels.

This is reusing the transform nomenclature but I believe it is most accurate
to describe a change on the raw request or response data.  I think the next
obvious change would be to use the same paradigm to set transforms and interceptors
on a per-action basis (replacing `transformRequest` and `transformResponse`)
to make the nomenclature less confusing.

The use case I am aiming for is to snakify keys on requests and camelize keys on responses in conjunction with Rails.